### PR TITLE
Update Node.js version to 11.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/actcat/devon_rex_base:1.0.9
 
 ENV NODE_VERSION=11.5.0
+ENV NPM_VERSION=6.5.0
+
 RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
     | tar -C /usr/local -x --xz --strip 1
+RUN npm install -g npm@$NPM_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/actcat/devon_rex_base:1.0.9
 
-ENV NODE_VERSION=8.11.3
+ENV NODE_VERSION=11.5.0
 RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
     | tar -C /usr/local -x --xz --strip 1


### PR DESCRIPTION
I updated Node.js version. Although we had used LTS version of Node, from now, we use the latest version excluding the initial release of a major version.

* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.11.3
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V9.md
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md

I checked that all smoke tests had passed with Node.js `11.5.0`.