### PR TITLE
Bump devon_rex_base version to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/actcat/devon_rex_base:1.2.1
+FROM quay.io/actcat/devon_rex_base:1.3.1
 
 ENV NODE_VERSION=11.5.0
 ENV NPM_VERSION=6.5.0


### PR DESCRIPTION
Just changing Docker image is sufficient for devon_rex_npm.