### PR TITLE
Install Yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM quay.io/actcat/devon_rex_base:1.3.1
 
 ENV NODE_VERSION=11.5.0
 ENV NPM_VERSION=6.5.0
+ENV YARN_VERSION=1.17.3
 
 RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
     | tar -C /usr/local -x --xz --strip 1
 RUN npm install -g npm@$NPM_VERSION
+RUN curl -o- -sSL https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION


### PR DESCRIPTION
See the [install guide](https://yarnpkg.com/en/docs/install#alternatives-stable).

I selected a non-package installation via `curl` because I think not good to depend on a specific package system like apt.

I verified on my local machine. It works. See the log below:

```
$ make
...

$ docker run -it --rm quay.io/actcat/devon_rex_npm:dev bash
root@ee4d1b63683d:/analyzer# npm -v
6.5.0
root@ee4d1b63683d:/analyzer# yarn -v
1.17.3
root@ee4d1b63683d:/analyzer# node -v
v11.5.0
```
