### PR TITLE
Fix Yarn installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,9 @@ ENV YARN_VERSION=1.17.3
 
 RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
     | tar -C /usr/local -x --xz --strip 1
+
 RUN npm install -g npm@$NPM_VERSION
-RUN curl -o- -sSL https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+
+RUN curl -o- -sSL https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION \
+    && ln -s $HOME/.yarn/bin/yarn /usr/local/bin/yarn \
+    && ln -s $HOME/.yarn/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 build:
 	docker build -t quay.io/actcat/devon_rex_npm:dev .
+
+test:
+	docker run -it --rm quay.io/actcat/devon_rex_npm:dev bash -c "node -v && npm -v && yarn -v"


### PR DESCRIPTION
This change makes symbolic links to `yarn` commands on `/usr/local/bin` (global `PATH`).

Why?
----

The Yarn install script writes the following line to `$HOME/.profile`:

```
export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
```

This is enabled only on login shell.

Also, this change adds `make test` command to verify installations.

When running `make test`, you will see the output:

```
$ make test
docker run -it --rm quay.io/actcat/devon_rex_npm:dev bash -c "node -v && npm -v && yarn -v"
v11.5.0
6.5.0
1.17.3
```

See #14 