### PR TITLE
Install Yarn via downloading file instead of the install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,5 @@ RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x
 
 RUN npm install -g npm@$NPM_VERSION
 
-RUN curl -o- -sSL https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION \
-    && ln -s $HOME/.yarn/bin/yarn /usr/local/bin/yarn \
-    && ln -s $HOME/.yarn/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN curl -sSL https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz \
+    | tar -C /usr/local -xz --strip 1


### PR DESCRIPTION
The Yarn's [install script](https://yarnpkg.com/install.sh) installs Yarn to a home directory of an execution user.
In the case of the Dockerfile, it is the `/root/.yarn/` directory.

As a result, other users cannot run Yarn in any scripts. For example:

```shell
sudo -u foo_user run_any_command #=> fail!
```

Instead of using the install script, this downloads directly the Yarn distribution file and installs it.

The distribution URL is according to the following official Node.js image:
https://github.com/nodejs/docker-node/blob/65b75dfb03a8604187b967340d626595c07e7445/12/stretch/Dockerfile#L55-L62